### PR TITLE
docs: hotfix requirements for requirement - correct file naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ git clone https://github.com/DeuroIO/erc20-ico-onchain-technical-analysis.git 
 
 Install necessary dependencies
 ```console
-$ pip install -r requirements.txt
+$ pip install -r requirement.txt
 ```
 
 ![img](http://www.dhanashriacademy.com/market/wp-content/uploads/2017/10/WHAT-IS-TECHNICAL-ANALYSIS.jpg)


### PR DESCRIPTION
## Issue
When running `pip install -f requirements.txt`, pip errors out since the filename is `requirement` not `requirements`.

> Could not open requirements file: [Errno 2] No such file or directory: 'requirements.txt'

## Debate
Wasn't sure if it's standard to use `requirement` or `requirements` as default naming convention for pip projects. If it's the latter we can decline this PR and change the filename itself.

## Tasks
* docs: hotfix requirements for requirement - correct file naming